### PR TITLE
Replacing scipy.misc with scipy.datasets

### DIFF
--- a/chapter_03/ricky.py
+++ b/chapter_03/ricky.py
@@ -1,13 +1,13 @@
 import numpy as np
 import matplotlib.pylab as plt
-import scipy.misc
+import scipy.datasets
 from PIL import Image
 
-im = scipy.misc.face(True)[:512,512:]
+im = scipy.datasets.face(True)[:512,512:]
 Image.fromarray(im).save("ricky.png")
 hr,xr = np.histogram(im, bins=256)
 hr = hr/hr.sum()
-im = scipy.misc.ascent().astype("uint8")
+im = scipy.datasets.ascent().astype("uint8")
 Image.fromarray(im).save("ascent.png")
 ha,xa = np.histogram(im, bins=256)
 ha = ha/ha.sum()


### PR DESCRIPTION
scipy.misc is deprecated; face and ascent have moved to scipy.datasets

See:
https://docs.scipy.org/doc/scipy-1.13.1/reference/generated/scipy.misc.face.html
https://docs.scipy.org/doc/scipy-1.12.0/reference/generated/scipy.misc.ascent.html